### PR TITLE
Remove trailing / for outdir path

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,7 @@
 // Required Parameters
 params.reads = "/scratch/$USER/gatk_hc_pipeline/data/*_R{1,2}_*.fastq.gz"
 params.ref = "/scratch/work/cgsb/genomes/Public/Fungi/Saccharomyces_cerevisiae/Ensembl/R64-1-1/Saccharomyces_cerevisiae.R64-1-1.dna.toplevel.fa"
-params.outdir = "/scratch/$USER/gatk_hc_pipeline/a/"
+params.outdir = "/scratch/$USER/gatk_hc_pipeline/a"
 params.snpeff_db = "Saccharomyces_cerevisiae"
 params.pl = "illumina"
 params.pm = "nextseq"


### PR DESCRIPTION
With the original trailing slash you can see the output line and the gatk temp dir below with a double /.

```
$ srun --mem 8GB nextflow run main.nf -with-singularity gencorefacility/variant-calling-pipeline-gatk4 -c nextflow.config
N E X T F L O W  ~  version 20.01.0
Launching `main.nf` [irreverent_euler] - revision: 17b19602bf
reads: /scratch/eb167/data/*_R{1,2}_*.fastq.gz
ref: /scratch/work/cgsb/genomes/Public/Fungi/Saccharomyces_cerevisiae/Ensembl/R64-1-1/Saccharomyces_cerevisiae.R64-1-1.dna.toplevel.fa
output: /scratch/eb167/gatk_hc_pipeline/a//out
gatk temp dir: /scratch/eb167/gatk_hc_pipeline/a//gatk_temp
snpeff db: Saccharomyces_cerevisiae
snpeff data: /scratch/eb167/gatk_hc_pipeline/a//snpeff_data
```